### PR TITLE
Hide non-mvp screens

### DIFF
--- a/src/navigation/MainTabNavigator.js
+++ b/src/navigation/MainTabNavigator.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { createBottomTabNavigator } from 'react-navigation';
-import HomeStack from './HomeStack';
+// import HomeStack from './HomeStack';
 import ElectionsStack from './ElectionsStack';
 import FavoritesStack from './FavoritesStack';
-import ActivismStack from './ActivismStack';
+// import ActivismStack from './ActivismStack';
 import TabBarIcon from './TabBarIcon';
 import colors from '../styles/colors';
 
@@ -13,13 +13,15 @@ import colors from '../styles/colors';
  */
 const MainTabNavigator = createBottomTabNavigator(
   {
-    Home: HomeStack,
+    // TODO: Implement stuff to show on home screen
+    // Home: HomeStack,
     Elections: ElectionsStack,
     Favorites: FavoritesStack,
-    Activism: ActivismStack,
+    // Activism: ActivismStack,
   },
   {
-    initialRouteName: 'Home',
+    // initialRouteName: 'Home',
+    initialRouteName: 'Elections',
     navigationOptions: ({ navigation }) => ({
       tabBarIcon: props => <TabBarIcon navigation={navigation} {...props} />,
     }),

--- a/src/screens/CandidateDetail/TabBar/index.js
+++ b/src/screens/CandidateDetail/TabBar/index.js
@@ -9,7 +9,7 @@ import TabItem from './TabItem';
 class TabBar extends Component {
   state = {
     selectedTab: 'Match',
-  }
+  };
 
   // Replace with Redux Action
   renderSelectedView = () => {
@@ -45,11 +45,12 @@ class TabBar extends Component {
             selectedTab={selectedTab}
             handlePress={handlePress}
           />
-          <TabItem
-            name='News'
-            selectedTab={selectedTab}
-            handlePress={handlePress}
-          />
+          {/* TODO: Implement news backend */}
+          {/*<TabItem*/}
+            {/*name='News'*/}
+            {/*selectedTab={selectedTab}*/}
+            {/*handlePress={handlePress}*/}
+          {/*/>*/}
         </View>
         <View styles={styles.viewArea}>
           {renderSelectedView()}


### PR DESCRIPTION
Hid Home screen, Activism screen, and news tab, and set app start screen to elections instead of home.  We can put these things back in as we implement the requirements 