### PR TITLE
Consolidate user data to make fewer firebase calls

### DIFF
--- a/App/appSagas.js
+++ b/App/appSagas.js
@@ -1,9 +1,14 @@
 import { all } from 'redux-saga/effects';
 import authSaga from '../src/auth/sagas';
+import userSaga from '../src/user/sagas';
 import electionsScreenSaga from '../src/screens/Elections/sagas';
 
-function* appSaga() {
-  yield all([authSaga(), electionsScreenSaga()]);
-}
+const appSaga = function*() {
+  yield all([
+    authSaga(),
+    electionsScreenSaga(),
+    userSaga(),
+  ]);
+};
 
 export default appSaga;

--- a/src/auth/__tests__/sagas.test.js
+++ b/src/auth/__tests__/sagas.test.js
@@ -78,7 +78,7 @@ describe('emailLoginSaga', () => {
     Array.from({ length: 3 }).forEach(() => {
       gen.next();
     });
-    expect(gen.next(user).value).toEqual(put(loginSuccess(user)));
+    expect(gen.next({ user }).value).toEqual(put(loginSuccess(user)));
   });
 
   it('dispatches the logout action when the api call errors', () => {
@@ -110,7 +110,7 @@ describe('facebookLoginSaga', () => {
   it('should call loginSuccess with the returned user', () => {
     const user = toFakeUser();
     gen.next();
-    expect(gen.next(user).value).toEqual(put(loginSuccess(user)));
+    expect(gen.next({ user }).value).toEqual(put(loginSuccess(user)));
   });
 
   it('dispatches the logout action when the api call errors', () => {
@@ -138,7 +138,7 @@ describe('googleLoginSaga', () => {
   it('should call loginSuccess with the returned user', () => {
     const user = toFakeUser();
     gen.next();
-    expect(gen.next(user).value).toEqual(put(loginSuccess(user)));
+    expect(gen.next({ user }).value).toEqual(put(loginSuccess(user)));
   });
 
   it('dispatches the logout action when the api call errors', () => {
@@ -181,7 +181,7 @@ describe('registerSaga', () => {
     Array.from({ length: 3 }).forEach(() => {
       gen.next();
     });
-    expect(gen.next(user).value).toEqual(put(loginSuccess(user)));
+    expect(gen.next({ user }).value).toEqual(put(loginSuccess(user)));
   });
 
   it('dispatches the logout action when the api call errors', () => {

--- a/src/auth/sagas.js
+++ b/src/auth/sagas.js
@@ -28,7 +28,7 @@ const generateLoginSaga = (asyncLoginFunction, requiresEmailAndPassword) => func
     } else {
       user = yield call(asyncLoginFunction);
     }
-    yield put(loginSuccess(user));
+    yield put(loginSuccess(user.user));
   } catch (err) {
     yield put(logOutAction());
     yield put(authFailure(err));

--- a/src/auth/selectors.js
+++ b/src/auth/selectors.js
@@ -3,7 +3,7 @@ import { parseErrorResponse } from './api';
 
 // User
 export const getLoggedInUser = state => state[AUTH_NAMESPACE].user;
-export const getLoggedInUserId = state => getLoggedInUser(state) && state[AUTH_NAMESPACE].user.id;
+export const getLoggedInUserId = state => getLoggedInUser(state) && getLoggedInUser(state).id;
 export const getIsLoggedIn = state => !!getLoggedInUser(state);
 export const getAuthError = state => state[AUTH_NAMESPACE].error;
 export const getIsLoading = state => state[AUTH_NAMESPACE].loading;

--- a/src/candidate/redux/candidates.js
+++ b/src/candidate/redux/candidates.js
@@ -3,11 +3,14 @@
 export const getCandidate = (state, id) => state[CANDIDATE_NAMESPACE][id];
 
 export const getCandidates = (state, viewMapper) => (
-  Object.keys(state[CANDIDATE_NAMESPACE]).map(id => viewMapper(getCandidate(state, id)))
+  getFilteredCandidates(state, viewMapper, Object.keys(state[CANDIDATE_NAMESPACE]))
+);
+
+export const getFilteredCandidates = (state, viewMapper, candidateIds) => (
+  candidateIds.map(id => viewMapper(getCandidate(state, id)))
 );
 
 // Action Creators
-
 export const loadCandidates = () => ({
   type: CandidateActionType.Request,
 });

--- a/src/favorites/api.js
+++ b/src/favorites/api.js
@@ -2,9 +2,9 @@ import { getByPath, setByPath } from '../firebase';
 import { Category } from './models';
 
 export const updateFavorite = (userId, favoriteId, isFavorite, category) =>
-  setByPath(`favorites/${userId}/${category}/${favoriteId}`, isFavorite);
+  setByPath(`${userId}/favorites/${category}/${favoriteId}`, isFavorite);
 
-export const fetchFavorites = userId => getByPath(`favorites/${userId}`).then(toFavorites);
+export const fetchFavorites = userId => getByPath(`${userId}/favorites`).then(toFavorites);
 
 export const toFavorites = apiFavorites => ({
   [Category.Candidates]: definedToArray(apiFavorites[Category.Candidates]),

--- a/src/favorites/redux.js
+++ b/src/favorites/redux.js
@@ -1,7 +1,7 @@
 import { Category } from './models';
+import { UserActionType } from '../user/sagas';
 
 // Selectors
-
 export const getUserFavorites = (state) => ({
   [Category.Candidates]: Array.from(getFavoritesForCategory(state, Category.Candidates)),
   [Category.Events]: Array.from(getFavoritesForCategory(state, Category.Events)),
@@ -18,10 +18,6 @@ const getFavoritesForCategory = (state, category) => (
 export const FAVORITES_NAMESPACE = 'favorites';
 
 // Action Creators
-export const loadFavorites = () => ({
-  type: FavoritesActionType.Request,
-});
-
 export const favoritesRequestSuccess = favorites => ({
   type: FavoritesActionType.RequestSuccess,
   payload: favorites,
@@ -47,8 +43,6 @@ const removeFavorite = (id, category) => ({
 });
 
 export const FavoritesActionType = {
-  Request: 'civicApp/favorites/request',
-  RequestSuccess: 'civicApp/favorites/requestSuccess',
   Toggle: 'civicApp/favorites/toggle',
   Add: 'civicApp/favorites/add',
   Remove: 'civicApp/favorites/remove',
@@ -59,10 +53,10 @@ export const FavoritesActionType = {
 const reducer = (state = initialState, action) => {
   let newState;
   switch (action.type) {
-    case FavoritesActionType.RequestSuccess:
+    case UserActionType.RequestSuccess:
       return {
-        [Category.Candidates]: new Set(action.payload[Category.Candidates]),
-        [Category.Events]: new Set(action.payload[Category.Events]),
+        [Category.Candidates]: new Set(action.payload.favorites[Category.Candidates]),
+        [Category.Events]: new Set(action.payload.favorites[Category.Events]),
       };
     case FavoritesActionType.Add:
       return {

--- a/src/favorites/redux.test.js
+++ b/src/favorites/redux.test.js
@@ -1,5 +1,6 @@
 import { Category } from './models';
 import reducer, { favoritesRequestSuccess, addOrRemoveFavorite } from './redux';
+import { userFetchSuccess } from '../user/sagas';
 
 
 describe('favorites reducer', () => {
@@ -7,8 +8,10 @@ describe('favorites reducer', () => {
     const canidateIds = ['foo', 'bar'];
     const eventIds = ['foobar', 'baz'];
     const payload = {
-      [Category.Candidates]: canidateIds,
-      [Category.Events]: eventIds,
+      favorites: {
+        [Category.Candidates]: canidateIds,
+        [Category.Events]: eventIds,
+      }
     };
     const initialState = {
       [Category.Candidates]: new Set(),
@@ -18,7 +21,7 @@ describe('favorites reducer', () => {
       [Category.Candidates]: new Set(canidateIds),
       [Category.Events]: new Set(eventIds),
     };
-    expect(reducer(initialState, favoritesRequestSuccess(payload))).toEqual(expectedState);
+    expect(reducer(initialState, userFetchSuccess(payload))).toEqual(expectedState);
   });
 
   it('updates state when adding a favorite', () => {

--- a/src/favorites/sagas.js
+++ b/src/favorites/sagas.js
@@ -1,7 +1,7 @@
 import { call, select, put } from 'redux-saga/effects';
 import { getLoggedInUserId } from '../auth/selectors';
-import { favoritesRequestSuccess, getIsFavorite, addOrRemoveFavorite } from './redux';
-import { fetchFavorites, updateFavorite } from './api';
+import { getIsFavorite, addOrRemoveFavorite } from './redux';
+import { updateFavorite } from './api';
 
 export const toggleFavoriteSaga = function*(action) {
   try {
@@ -12,15 +12,5 @@ export const toggleFavoriteSaga = function*(action) {
   } catch (err) {
     // TODO: display error message about failure
     yield put(addOrRemoveFavorite(action.payload.id, action.payload.category));
-  }
-};
-
-export const loadFavoritesSaga = function*() {
-  try {
-    const userId = yield select(getLoggedInUserId);
-    const favorites = yield call(fetchFavorites, userId);
-    yield put(favoritesRequestSuccess(favorites));
-  } catch (err) {
-    // TODO: handle error
   }
 };

--- a/src/match/api.js
+++ b/src/match/api.js
@@ -1,0 +1,6 @@
+import { setByPath } from '../firebase/initialize';
+
+// newResponses should be an object: { [questionId]: { ...response values }
+export const saveUserResponses = (userId, newResponses) => (
+  setByPath(`users/${userId}/responses`, newResponses)
+);

--- a/src/screens/Elections/ScreenContainer.js
+++ b/src/screens/Elections/ScreenContainer.js
@@ -1,22 +1,26 @@
 import { connect } from 'react-redux';
 import { compose, lifecycle } from 'recompose';
-import Screen from './Screen';
 import { getCandidates, loadCandidates } from '../../candidate/redux/candidates';
+import { loadUser } from '../../user/sagas'
 import { getIsLoggedIn } from '../../auth/selectors';
-import { loadFavorites } from '../../favorites/redux';
 import WithAuthentication from '../../util/components/WithAuthentication';
+import Screen from './Screen';
 
 const ScreenWithAuthentication = WithAuthentication('logout')(Screen);
 
 const Container = compose(
   connect(
-    state => ({ candidates: getCandidates(state, toListCandidateMapperPlaceholder), isLoggedIn: getIsLoggedIn(state) }),
-    { loadCandidates, loadFavorites },
+    state => ({
+      candidates: getCandidates(state, toListCandidateMapperPlaceholder),
+      isLoggedIn: getIsLoggedIn(state),
+    }),
+    { loadCandidates, loadUser },
   ),
   lifecycle({
     componentDidMount() {
       this.props.loadCandidates();
-      this.props.loadFavorites();
+      // TODO: only load user if match data has not been loaded yet
+      this.props.loadUser();
     },
   }),
 )(ScreenWithAuthentication);

--- a/src/screens/Elections/sagas.js
+++ b/src/screens/Elections/sagas.js
@@ -1,11 +1,10 @@
 import { takeEvery } from 'redux-saga/effects';
 import { loadCandidatesSaga } from '../../candidate/sagas';
 import { CandidateActionType } from '../../candidate/redux/candidates';
-import { loadFavoritesSaga, toggleFavoriteSaga } from '../../favorites/sagas';
+import { toggleFavoriteSaga } from '../../favorites/sagas';
 import { FavoritesActionType } from '../../favorites/redux';
 
 export default function*() {
   yield takeEvery(CandidateActionType.Request, loadCandidatesSaga);
-  yield takeEvery(FavoritesActionType.Request, loadFavoritesSaga);
   yield takeEvery(FavoritesActionType.Toggle, toggleFavoriteSaga);
 }

--- a/src/screens/Favorites/FavoritesPreviewContainer.js
+++ b/src/screens/Favorites/FavoritesPreviewContainer.js
@@ -2,12 +2,15 @@ import { connect } from 'react-redux';
 import { compose, lifecycle } from 'recompose';
 import FavoritesPreview from './FavoritesPreview';
 import WithAuthentication from '../../util/components/WithAuthentication';
-import { getCandidates, loadCandidates } from '../../candidate/redux/candidates'
-import { loadFavorites } from '../../favorites/redux';
+import { getFilteredCandidates, loadCandidates } from '../../candidate/redux/candidates'
+import { loadUser } from '../../user/sagas'
 import { getIsLoggedIn } from '../../auth/selectors';
+import { getUserFavorites } from '../../favorites/redux';
+import { Category } from '../../favorites/models';
 
-export const getFavoriteCandidateData  = state => {
-  return getCandidates(state,toListCandidateMapper);
+export const getFavoriteCandidateData  = (state) => {
+  const favoriteCandidateIds = getUserFavorites(state)[Category.Candidates];
+  return getFilteredCandidates(state, toListCandidateMapper, favoriteCandidateIds);
 };
 
 const ScreenWithAuthentication = WithAuthentication('logout')(FavoritesPreview);
@@ -18,12 +21,13 @@ const Container = compose(
       data: getFavoriteCandidateData(state, ownprops.candidateId),
       isLoggedIn: getIsLoggedIn(state),
     }),
-    { loadCandidates, loadFavorites },
+    { loadCandidates, loadUser },
   ),
   lifecycle({
     componentDidMount() {
+      // TODO: only load if not already loaded
       this.props.loadCandidates();
-      this.props.loadFavorites();
+      this.props.loadUser();
     },
   }),
 )(ScreenWithAuthentication);

--- a/src/user/api.js
+++ b/src/user/api.js
@@ -1,0 +1,12 @@
+import { getByPath } from '../firebase/initialize';
+import { toFavorites } from '../favorites/api';
+
+export const fetchUser = (id) => (
+  getByPath(`users/${id}`)
+    .then(toUser)
+);
+
+const toUser = (apiUser) => ({
+  ...apiUser,
+  favorites: toFavorites(apiUser.favorites),
+});

--- a/src/user/sagas.js
+++ b/src/user/sagas.js
@@ -7,8 +7,8 @@ export const loadUserDataSaga = function*() {
   try {
     const userId = yield select(getLoggedInUserId);
     if (userId) {
-      const { responses, favorites, ...user } = yield call(fetchUser, userId);
-      yield put(userFetchSuccess(responses, favorites, user))
+      const userResponse = yield call(fetchUser, userId);
+      yield put(userFetchSuccess(userResponse))
     } else {
       yield call(logOutSaga)
     }
@@ -18,7 +18,7 @@ export const loadUserDataSaga = function*() {
   }
 };
 
-export const userFetchSuccess = (responses, favorites, user) => ({
+export const userFetchSuccess = ({ responses, favorites, user }) => ({
   type: UserActionType.RequestSuccess,
   payload: { responses, favorites, user },
 });

--- a/src/user/sagas.js
+++ b/src/user/sagas.js
@@ -1,0 +1,38 @@
+import { call, select, put, takeEvery } from 'redux-saga/effects';
+import { getLoggedInUserId } from '../auth/redux';
+import { logOutSaga } from '../auth/sagas';
+import { fetchUser } from './api';
+
+export const loadUserDataSaga = function*() {
+  try {
+    const userId = yield select(getLoggedInUserId);
+    if (userId) {
+      const { responses, favorites, ...user } = yield call(fetchUser, userId);
+      yield put(userFetchSuccess(responses, favorites, user))
+    } else {
+      yield call(logOutSaga)
+    }
+
+  } catch (err) {
+    // TODO: handle error
+  }
+};
+
+export const userFetchSuccess = (responses, favorites, user) => ({
+  type: UserActionType.RequestSuccess,
+  payload: { responses, favorites, user },
+});
+
+export const loadUser = (force = false) => ({
+  type: UserActionType.Request,
+  payload: force
+});
+
+export const UserActionType = {
+  Request: 'civicApp/user/REQUEST',
+  RequestSuccess: 'civicApp/user/REQUEST_SUCCESS',
+};
+
+export default function*() {
+  yield takeEvery(UserActionType.Request, loadUserDataSaga);
+}

--- a/src/user/sagas.js
+++ b/src/user/sagas.js
@@ -1,5 +1,5 @@
 import { call, select, put, takeEvery } from 'redux-saga/effects';
-import { getLoggedInUserId } from '../auth/redux';
+import { getLoggedInUserId } from '../auth/selectors';
 import { logOutSaga } from '../auth/sagas';
 import { fetchUser } from './api';
 

--- a/src/util/components/WithAuthentication.js
+++ b/src/util/components/WithAuthentication.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
  * getting into an infinite redirect because the user never appears to be logged in
  * even if they are.
  */
-const WithAuthentication = authAction => (WrappedComponent) => {
+const WithAuthentication = authAction => WrappedComponent => {
   return class extends React.Component {
     static propTypes = {
       isLoggedIn: PropTypes.bool.isRequired,

--- a/testData/mockData.json
+++ b/testData/mockData.json
@@ -73,16 +73,30 @@
       "id": "Ra6l4NfjcLcc8XdP4gX1aWdhRRd2",
       "address": "125 W 125th st, New York, NY, 10001",
       "district": "10",
-      "responseIds": [
-        "Ra6l4NfjcLfewafeX1aWdhRRd2"
-      ]
-    }
-  },
-  "userResponses": {
-    "Ra6l4NfjcLfewafeX1aWdhRRd2": {
-      "id": "Ra6l4NfjcLfewafeX1aWdhRRd2",
-      "questionId": "8bb9a280-6ea8-11e8-b566-0800200c9a66",
-      "questionResponse": 5
+      "responses": {
+        "8bb9a280-6ea8-11e8-b566-0800200c9a66": {
+          "questionId": "8bb9a280-6ea8-11e8-b566-0800200c9a66",
+          "questionResponse": 2
+        },
+        "33f3204d0e5d4a69b614b97eb18b9b9c": {
+          "questionId": "33f3204d0e5d4a69b614b97eb18b9b9c",
+          "questionResponse": 2
+        },
+        "e54d81349a0e40eb900d9eb7744a9480": {
+          "questionId": "e54d81349a0e40eb900d9eb7744a9480",
+          "questionResponse": 2
+        },
+        "3a0715f1b6224fad8f1dcecea3b228b7": {
+          "questionId": "3a0715f1b6224fad8f1dcecea3b228b7",
+          "questionResponse": 2
+        }
+      },
+      "favorites": {
+        "candidates": {
+          "c88d3aa0-6ea8-11e8-b566-0800200c9a66": true
+        },
+        "events": {}
+      }
     }
   },
   "elections": {
@@ -91,12 +105,5 @@
       "name": "California Governor"
     }
   },
-  "favorites": {
-    "Ra6l4NfjcLcc8XdP4gX1aWdhRRd2": {
-      "candidates": {
-        "c88d3aa0-6ea8-11e8-b566-0800200c9a66": true
-      },
-      "events": {}
-    }
-  }
+
 }

--- a/testData/mockUser.json
+++ b/testData/mockUser.json
@@ -1,0 +1,29 @@
+{
+  "id": "Ra6l4NfjcLcc8XdP4gX1aWdhRRd2",
+  "address": "125 W 125th st, New York, NY, 10001",
+  "district": "10",
+  "responses": {
+    "8bb9a280-6ea8-11e8-b566-0800200c9a66": {
+      "questionId": "8bb9a280-6ea8-11e8-b566-0800200c9a66",
+        "questionResponse": 2
+    },
+    "33f3204d0e5d4a69b614b97eb18b9b9c": {
+      "questionId": "33f3204d0e5d4a69b614b97eb18b9b9c",
+        "questionResponse": 2
+    },
+    "e54d81349a0e40eb900d9eb7744a9480": {
+      "questionId": "e54d81349a0e40eb900d9eb7744a9480",
+        "questionResponse": 2
+    },
+    "3a0715f1b6224fad8f1dcecea3b228b7": {
+      "questionId": "3a0715f1b6224fad8f1dcecea3b228b7",
+        "questionResponse": 2
+    }
+  },
+    "favorites": {
+    "candidates": {
+      "c88d3aa0-6ea8-11e8-b566-0800200c9a66": true
+    },
+    "events": {}
+  }
+}


### PR DESCRIPTION
As much as I am a relational purist, it seems to we will always want all the user data, and storing it together in the user object, and fetching it together probably makes more sense.

The way I see this working is that on load of the first logged in page, we fetch all the user data, and then don't have to fetch it again.