### PR TITLE
Update match function with certainty

### DIFF
--- a/src/match/calculate.js
+++ b/src/match/calculate.js
@@ -1,12 +1,13 @@
 export const calculateMatch = (userPositions, candidatePositions) => {
   const { totalGap, maxGap, numUnknown } = calculatePositionsGap(userPositions, candidatePositions);
+  console.log('cert', totalGap/maxGap, totalGap, maxGap)
   return {
     match: (
       maxGap > 0 // 0 max gap means candidate and user have no questions on which they both expressed an opinion
-        ? +(Math.round(((1 - totalGap/maxGap) * 100) + 'e+2')  + 'e-2')
+        ? toRoundedPercent(1 - totalGap/maxGap)
         : 0 // TODO: maybe add a real placeholder when candidate data is all in place
     ),
-    certainty: maxGap / (maxGap + numUnknown),
+    certainty: toRoundedPercent(maxGap / (maxGap + numUnknown)),
   };
 };
 
@@ -48,3 +49,5 @@ export const getPositionResponse = (id, positions) => (
 
 const hasUserAndCandidateScores = (userScore, candidateScore) =>
   (typeof userScore === 'number') && (typeof candidateScore === 'number');
+
+const toRoundedPercent = num => Math.round(num * 100);

--- a/src/match/calculate.js
+++ b/src/match/calculate.js
@@ -1,34 +1,37 @@
 export const calculateMatch = (userPositions, candidatePositions) => {
-  const [gap, maxGap] = calculatePositionsGap(userPositions, candidatePositions);
-  return (
-    maxGap > 0 // 0 max gap means candidate and user have no questions on which they both expressed an opinion
-      ? +(Math.round(((1 - gap/maxGap) * 100) + 'e+2')  + 'e-2')
-      : 0 // TODO: maybe add a real placeholder when candidate data is all in place
-  );
+  const { totalGap, maxGap, numUnknown } = calculatePositionsGap(userPositions, candidatePositions);
+  return {
+    match: (
+      maxGap > 0 // 0 max gap means candidate and user have no questions on which they both expressed an opinion
+        ? +(Math.round(((1 - totalGap/maxGap) * 100) + 'e+2')  + 'e-2')
+        : 0 // TODO: maybe add a real placeholder when candidate data is all in place
+    ),
+    certainty: maxGap / (maxGap + numUnknown),
+  };
 };
 
 const calculatePositionsGap = (userPositions, candidatePositions) => (
   Object.keys(userPositions).reduce(
-    ([totalSoFar, maxSoFar], id) => {
+    ({ totalGap, maxGap, numUnknown }, id) => {
       const userScore = getPositionResponse(id, userPositions);
       const candidateScore = getPositionResponse(id, candidatePositions);
-      const [gap, max] = hasUserAndCandidateScores(userScore, candidateScore)
+      const { gap, max, unknown } = hasUserAndCandidateScores(userScore, candidateScore)
         ? calculateGapForSingle(userScore, candidateScore)
-        : [0, 0];
-      return [gap + totalSoFar, max + maxSoFar];
+        : { gap: 0, maxGap2: 0, unknown: 1 };
+      return {totalGap: totalGap + gap, maxGap: maxGap + max, numUnknown: numUnknown + unknown };
     },
-    [0, 0])
+    { totalGap: 0, maxGap: 0, numUnknown: 0 })
 );
 
 export const calculateGapForSingle = (user, candidate) => {
-  if (isUserNeutral(user)) {
-    return [0, 0];
+  if (isNeutral(user)) {
+    return { gap: 0, max: 0, unknown: 0 };
   } else if (isAgreement(user, candidate)) {
-    return [0, 4];
-  } else if (candidate === 0) {
-    return [Math.abs(user), 4];
+    return { gap: 0, max: 1, unknown: 0 };
+  } else if (isNeutral(candidate)) {
+    return { gap: Math.abs(user)/4, max: 1, unknown: 1 };
   } else { // not in agreement
-    return [1 + Math.abs(candidate - user), 4];
+    return { gap: (1 + Math.abs(candidate - user))/4, max: 1, unknown: 0 };
   }
 };
 
@@ -37,7 +40,7 @@ export const isAgreement = (user, candidate) => (
   || (candidate < 0 && user < 0)
 );
 
-export const isUserNeutral = user => user === 0;
+export const isNeutral = answer => answer === 0;
 
 export const getPositionResponse = (id, positions) => (
   positions && positions[id] && positions[id].response

--- a/src/match/calculate.test.js
+++ b/src/match/calculate.test.js
@@ -16,7 +16,7 @@ describe('calculateMatch', () => {
       'd': { response: 1 },
       'e': { response: -1 },
     };
-    expect(calculateMatch(userPositions, candidatePositions)).toEqual({ match: 68.75, certainty: .8 });
+    expect(calculateMatch(userPositions, candidatePositions)).toEqual({ match: 69, certainty: 80 });
   })
 });
 

--- a/src/match/calculate.test.js
+++ b/src/match/calculate.test.js
@@ -16,40 +16,40 @@ describe('calculateMatch', () => {
       'd': { response: 1 },
       'e': { response: -1 },
     };
-    expect(calculateMatch(userPositions, candidatePositions)).toEqual(68.75);
+    expect(calculateMatch(userPositions, candidatePositions)).toEqual({ match: 68.75, certainty: .8 });
   })
 });
 
 describe('calculateGapForSingle', () => {
   it('handles agreement', () => {
-    expect(calculateGapForSingle(1, 1)).toEqual([0, 4]);
-    expect(calculateGapForSingle(-1, -1)).toEqual([0, 4]);
+    expect(calculateGapForSingle(1, 1)).toEqual({ gap: 0, max: 1, unknown: 0});
+    expect(calculateGapForSingle(-1, -1)).toEqual({ gap: 0, max: 1, unknown: 0});
   });
 
   it('handles agreement with strong agreement', () => {
-    expect(calculateGapForSingle(2, 1)).toEqual([0, 4]);
-    expect(calculateGapForSingle(-2, -1)).toEqual([0, 4]);
+    expect(calculateGapForSingle(2, 1)).toEqual({ gap: 0, max: 1, unknown: 0});
+    expect(calculateGapForSingle(-2, -1)).toEqual({ gap: 0, max: 1, unknown: 0});
   });
 
   it('handles neutral candidate', () => {
-    expect(calculateGapForSingle(1, 0)).toEqual([1, 4]);
-    expect(calculateGapForSingle(-1, 0)).toEqual([1, 4]);
-    expect(calculateGapForSingle(2, 0)).toEqual([2, 4]);
-    expect(calculateGapForSingle(-2, 0)).toEqual([2, 4]);
+    expect(calculateGapForSingle(1, 0)).toEqual({ gap: .25, max: 1, unknown: 1});
+    expect(calculateGapForSingle(-1, 0)).toEqual({ gap: .25, max: 1, unknown: 1});
+    expect(calculateGapForSingle(2, 0)).toEqual({ gap: .5, max: 1, unknown: 1});
+    expect(calculateGapForSingle(-2, 0)).toEqual({ gap: .5, max: 1, unknown: 1});
   });
 
   it('returns no max when user is neutral', () => {
-    expect(calculateGapForSingle(0, 1)).toEqual([0, 0]);
-    expect(calculateGapForSingle(0, -1)).toEqual([0, 0]);
+    expect(calculateGapForSingle(0, 1)).toEqual({ gap: 0, max: 0, unknown: 0});
+    expect(calculateGapForSingle(0, -1)).toEqual({ gap: 0, max: 0, unknown: 0});
   });
 
   it('handles disagreement', () => {
-    expect(calculateGapForSingle(1, -1)).toEqual([3, 4]);
-    expect(calculateGapForSingle(-1, 1)).toEqual([3, 4]);
+    expect(calculateGapForSingle(1, -1)).toEqual({ gap: .75, max: 1, unknown: 0});
+    expect(calculateGapForSingle(-1, 1)).toEqual({ gap: .75, max: 1, unknown: 0});
   });
 
   it('handles strong disagreement', () => {
-    expect(calculateGapForSingle(2, -1)).toEqual([4, 4]);
-    expect(calculateGapForSingle(-2, 1)).toEqual([4, 4]);
+    expect(calculateGapForSingle(2, -1)).toEqual({ gap: 1, max: 1, unknown: 0});
+    expect(calculateGapForSingle(-2, 1)).toEqual({ gap: 1, max: 1, unknown: 0});
   });
 });

--- a/src/match/selectors.js
+++ b/src/match/selectors.js
@@ -5,6 +5,7 @@ import { calculateMatch } from './calculate';
 
 export const getMatchPercent = (state, candidateId) => getMatchData(state, candidateId).match;
 export const getCertaintyPercent = (state, candidateId) => getMatchData(state, candidateId).certainty;
+export const shouldShowMatchPercent = (state, candidateId) => getMatchData(state, candidateId).certainty > 50;
 
 export const getMatchData = (state, candidateId) => {
   const userPositions = getUserPositions(state);

--- a/src/match/selectors.js
+++ b/src/match/selectors.js
@@ -3,7 +3,10 @@ import { getPositionsForCandidate } from '../candidate/redux/positions';
 import { getUserPositions } from './redux';
 import { calculateMatch } from './calculate';
 
-export const getMatchPercent = (state, candidateId) => {
+export const getMatchPercent = (state, candidateId) => getMatchData(state, candidateId).match;
+export const getCertaintyPercent = (state, candidateId) => getMatchData(state, candidateId).certainty;
+
+export const getMatchData = (state, candidateId) => {
   const userPositions = getUserPositions(state);
   const candidatePositions = getPositionsForCandidate(state, candidateId);
   return userPositions && candidatePositions &&

--- a/src/screens/CandidateDetail/viewSelectors.js
+++ b/src/screens/CandidateDetail/viewSelectors.js
@@ -4,7 +4,7 @@ import { Category } from '../../favorites/models';
 import { getMatchPercent } from '../../match/selectors';
 import { getSurveyQuestions, getUserPositions } from '../../match/redux';
 import { getPositionsForCandidate } from '../../candidate/redux/positions';
-import { getPositionResponse, isAgreement, isUserNeutral } from '../../match/calculate';
+import { getPositionResponse, isAgreement, isNeutral } from '../../match/calculate';
 
 export const getCandidateSummary = (state, candidateId) => {
   const candidate = getCandidate(state, candidateId);
@@ -40,7 +40,7 @@ const getMatchTabProps = (state, candidateId) => {
         const userResponse = getPositionResponse(questionId, userPositions);
         const candidateResponse = getPositionResponse(questionId, candidatePositions);
         // TODO: how to handle neutral user
-        const agreesWithUser = isAgreement(userResponse, candidateResponse) || isUserNeutral(userResponse);
+        const agreesWithUser = isAgreement(userResponse, candidateResponse) || isNeutral(userResponse);
         return {
           id: questionId,
           type: surveyQuestions[questionId] && surveyQuestions[questionId].type || 'other',


### PR DESCRIPTION
Adds certainty percent to match calc.  You can use `getCertaintyPercent` selector to access it.
We thought that greater than 50% uncertainty should not show the match, and I made a selector for this: `shouldShowMatchPercent`, which can be used by the view to hide the match percent